### PR TITLE
New header

### DIFF
--- a/themes/brooklynrail/assets/scss/_common.scss
+++ b/themes/brooklynrail/assets/scss/_common.scss
@@ -1,0 +1,45 @@
+// Common type elements
+
+// ====================================================
+// Links with border bottom
+// In some cases, it is better to apply `border-bottom` to the button or link vs having it apply the underline
+
+// Example:
+// <a class="u-white" href="" title=""><span class="u">Donate</span></a>
+
+// - u-primary (dotted, red-50v)
+// - u-primary-dotted
+// - u-black
+// - u-white
+a.u-primary {
+  @include u-text('no-underline');
+  &:hover{
+    span.u{
+      @include u-border-bottom('2px', 'solid', 'primary');
+    }
+  }
+}
+a.u-primary-dotted {
+  @include u-text('no-underline');
+  &:hover{
+    span.u{
+      @include u-border-bottom('2px', 'dotted', 'primary');
+    }
+  }
+}
+a.u-black {
+  @include u-text('no-underline');
+  &:hover{
+    span.u{
+      @include u-border-bottom('2px', 'solid', 'black');
+    }
+  }
+}
+a.u-white {
+  @include u-text('no-underline');
+  &:hover{
+    span.u{
+      @include u-border-bottom('2px', 'solid', 'white');
+    }
+  }
+}

--- a/themes/brooklynrail/assets/scss/_header.scss
+++ b/themes/brooklynrail/assets/scss/_header.scss
@@ -1,0 +1,3 @@
+.header{
+  @include u-padding-y(2);
+}

--- a/themes/brooklynrail/assets/scss/_main-nav.scss
+++ b/themes/brooklynrail/assets/scss/_main-nav.scss
@@ -1,0 +1,38 @@
+.main-nav{
+  // @include u-padding-y(1);
+
+  .nav{
+    @include u-padding-y(1);
+    @include u-border-y('2px', 'dotted', 'black');
+    ul{
+      @include add-list-reset();
+      li{
+        @include u-display('inline-block');
+        @include u-font('sans', 'md');
+        @include u-text('medium');
+        @include u-text('primary');
+        a{
+          @include u-padding-y('105');
+          @include u-padding-x('105');
+          @include u-text('primary');
+          @include u-display('inline-block');
+        }
+        &:first-child{
+          a{
+            @include u-padding-left(0);
+          }
+        }
+      }
+      .donate{
+        @include u-float('right');
+        @include u-text('uppercase');
+        a{
+          @include u-bg('primary');
+          @include u-padding-x('205');
+          @include u-radius('sm');
+          @include u-text('white');
+        }
+      }
+    }
+  }
+}

--- a/themes/brooklynrail/assets/scss/styles.scss
+++ b/themes/brooklynrail/assets/scss/styles.scss
@@ -69,3 +69,10 @@
 // Import theme custom styles
 
 // @import "uswds-theme-custom-styles";
+
+
+
+@import "common";     // Common type styles
+
+@import "header";     // Site-wide header
+@import "main-nav";   // Site-wide navigation

--- a/themes/brooklynrail/assets/scss/uswds/_uswds-theme-spacing.scss
+++ b/themes/brooklynrail/assets/scss/uswds/_uswds-theme-spacing.scss
@@ -87,7 +87,7 @@ Site
 ----------------------------------------
 */
 
-$theme-site-max-width: "desktop-lg";
+$theme-site-max-width: "widescreen";
 $theme-site-margins-breakpoint: "desktop";
-$theme-site-margins-width: 4;
+$theme-site-margins-width: 3;
 $theme-site-margins-mobile-width: 2;

--- a/themes/brooklynrail/layouts/_default/baseof.html
+++ b/themes/brooklynrail/layouts/_default/baseof.html
@@ -4,8 +4,12 @@
   {{ partial "head.html" . }}
 
   <body class="{{ $.Param "body_classes"  | default "" }}{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
+    <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 
-    {{ block "header" . }}{{ partialCached "header.html" . }}{{ end }}
+    {{ block "header" . }}
+      {{ partialCached "header.html" . }}
+      {{ partialCached "main-nav.html" . }}
+    {{ end }}
 
     {{ block "main" . }}{{ end }}
 

--- a/themes/brooklynrail/layouts/partials/header.html
+++ b/themes/brooklynrail/layouts/partials/header.html
@@ -1,52 +1,13 @@
 <div class="usa-overlay"></div>
-<header class="usa-header usa-header--basic">
-  <img class="" src="{{- "img/brooklynrail-logo-outline-red.svg" | relURL -}}" alt="{{- $.Site.Title -}} Logo" />
-  <div class="usa-nav-container">
-    <div class="usa-navbar">
-      <div class="usa-logo" id="basic-logo">
-        <em class="usa-logo__text">
-          <a href="/" title="Home | {{ .Title | default .Site.Title }}" aria-label="Home">
-            <img src="" alt="">
-            <img class="" src="{{- "img/brooklynrail-logo-outline-red.svg" | relURL -}}" alt="{{- $.Site.Title -}} Logo" />
-          </a>
-        </em>
-      </div>
-      <button class="usa-menu-btn">Menu</button>
-    </div>
 
-    <nav aria-label="Primary navigation" class="usa-nav">
-      <button class="usa-nav__close"><img src="/assets/img/close.svg" alt="close"></button>
-      <ul class="usa-nav__primary usa-accordion">
-        <li class="usa-nav__primary-item">
-          <button class="usa-accordion__button usa-nav__link  usa-current" aria-expanded="false" aria-controls="basic-nav-section-one"><span>Current section</span></button>
-          <ul id="basic-nav-section-one" class="usa-nav__submenu">
-            <li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li>
-            <li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li>
-            <li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li>
-          </ul>
-        </li>
-        <li class="usa-nav__primary-item">
-          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="basic-nav-section-two"><span>Section</span></button>
-          <ul id="basic-nav-section-two" class="usa-nav__submenu">
-            <li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li><li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li><li class="usa-nav__submenu-item">
-              <a href="#">Navigation link</a>
-            </li>
-          </ul>
-        </li>
-        <li class="usa-nav__primary-item">
-          <a class="usa-nav__link" href="{{ "/events" | relURL }}"><span>Events</span></a>
-        </li>
-      </ul>
-    </nav>
+<header class="header">
+  <div class="grid-container grid-container-widescreen">
+    <div class="grid-row">
+      <div class="grid-col-fill">
+        <a class="" href="/" accesskey="1" title="Home" aria-label="{{ .Site.Title }}">
+          <img class="" src="{{- "img/brooklynrail-logo-outline-red.svg" | relURL -}}" alt="{{- $.Site.Title -}} Logo" />
+        </a>
+      </div>
+    </div>
   </div>
 </header>

--- a/themes/brooklynrail/layouts/partials/main-nav.html
+++ b/themes/brooklynrail/layouts/partials/main-nav.html
@@ -1,0 +1,19 @@
+<nav class="main-nav">
+  <div class="grid-container grid-container-widescreen">
+    <div class="grid-row">
+      <div class="grid-col-12">
+        <div class="nav">
+          <ul>
+            <li><a class="u-primary" href="#" title=""><span class="u">Home</span></a></li>
+            <li><a class="u-primary" href="#" title=""><span class="u">Current Issue</span></a></li>
+            <li><a class="u-primary" href="#" title=""><span class="u">Events</span></a></li>
+            <li><a class="u-primary" href="#" title=""><span class="u">About the Rail</span></a></li>
+            <li><a class="u-primary" href="#" title=""><span class="u">Subscribe</span></a></li>
+            <li><a class="u-primary" href="#" title=""><span class="u">Store</span></a></li>
+            <li class="donate"><a class="u-white" href="" title=""><span class="u">Donate</span></a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
This adds a new header to the site, based roughly off of the work we did on https://venice.brooklynrail.org/. 

The header include is included in a `{{ block }}` which will allow page templates to override it in the future.

Also established some better practices for organizing styles by including a `common.scss` file for common type elements and documenting how they are used.