### PR TITLE
Media location

### DIFF
--- a/content/events-beta/2020/2020-04-20-stanley-whitney-with-tom-mcglynn.md
+++ b/content/events-beta/2020/2020-04-20-stanley-whitney-with-tom-mcglynn.md
@@ -13,7 +13,7 @@ end_date: 2020-04-20 14:00:00 -0500
 event_platform:
   - zoom
 featured_images:
-  - the-ocean
+  - media: 2020-05-stanley-whitney
 ---
 
 ## The New Social Environment

--- a/content/events-beta/2020/2020-04-20-stanley-whitney-with-tom-mcglynn.md
+++ b/content/events-beta/2020/2020-04-20-stanley-whitney-with-tom-mcglynn.md
@@ -13,7 +13,7 @@ end_date: 2020-04-20 14:00:00 -0500
 event_platform:
   - zoom
 featured_images:
-  - img_url: https://brooklynrail-web.imgix.net/article_image/image/24689/whitney-stanley-2-finalweb.jpg?w=440&q=80&fit=max
+  - the-ocean
 ---
 
 ## The New Social Environment

--- a/content/events-beta/2020/2020-04-21-peter-brook-with-karen-brooks-hopkins-and-bryan-doerries.md
+++ b/content/events-beta/2020/2020-04-21-peter-brook-with-karen-brooks-hopkins-and-bryan-doerries.md
@@ -13,8 +13,7 @@ date: 2020-04-21 13:00:00 -0500
 end_date: 2020-04-21 14:00:00 -0500
 event_platform:
   - zoom
-featured_images:
-  - img_url: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F98460586%2F250527606728%2F1%2Foriginal.20200410-204950?h=2000&w=720&auto=format%2Ccompress&q=75&sharp=10&s=8649b025d9637aa49fc1c6759d7c09ee
+
 ---
 ## The New Social Environment
 

--- a/content/events-beta/2020/2020-04-21-peter-brook-with-karen-brooks-hopkins-and-bryan-doerries.md
+++ b/content/events-beta/2020/2020-04-21-peter-brook-with-karen-brooks-hopkins-and-bryan-doerries.md
@@ -13,7 +13,6 @@ date: 2020-04-21 13:00:00 -0500
 end_date: 2020-04-21 14:00:00 -0500
 event_platform:
   - zoom
-
 ---
 ## The New Social Environment
 

--- a/content/events-beta/2020/2020-04-22-lauren-bon-with-phong-bui.md
+++ b/content/events-beta/2020/2020-04-22-lauren-bon-with-phong-bui.md
@@ -12,8 +12,6 @@ date: 2020-04-22 13:00:00 -0500
 end_date: 2020-04-22 14:00:00 -0500
 event_platform:
   - zoom
-featured_images:
-  - img_url: https://venice.brooklynrail.org/assets/media/rail-venice-courtyard.png
 ---
 ## The New Social Environment
 

--- a/content/events-beta/2020/2020-04-27-lyle-ashton-harris-with-mckenzie-wark.md
+++ b/content/events-beta/2020/2020-04-27-lyle-ashton-harris-with-mckenzie-wark.md
@@ -12,8 +12,6 @@ end_date: 2020-04-27 14:00:00 -0500
 event_platform:
   - zoom
   - youtube
-featured_images:
-  - img_url: https://brooklynrail-web.imgix.net/article_image/image/23068/Bui-Harris-1.jpg?w=600&q=80&fit=max
 ---
 
 

--- a/content/events-beta/2020/2020-04-28-dorothea-rockburne-with-phyllis-tuchman.md
+++ b/content/events-beta/2020/2020-04-28-dorothea-rockburne-with-phyllis-tuchman.md
@@ -12,8 +12,6 @@ end_date: 2020-04-28 14:00:00 -0500
 event_platform:
   - zoom
   - youtube
-featured_images:
-  - img_url: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F99205246%2F250527606728%2F1%2Foriginal.20200421-204356?h=2000&w=720&auto=format%2Ccompress&q=75&sharp=10&s=41ed5b545656746c0654796ed2e73e9f
 ---
 **Dorothea Rockburne** is an artist, born in Montréal, who lives and works in New York. Most recently, she had a solo show installed for long-term view at Dia:Beacon in 2018.
 

--- a/content/media/2020-05-rail-zoom.md
+++ b/content/media/2020-05-rail-zoom.md
@@ -1,6 +1,0 @@
----
-media: /media/rail-zoom-1.png
-name: Rail Zoom
-alt: Rail Zoom grid
-date: 2020-05-03 15:14:00 -0500
----

--- a/content/media/_index.md
+++ b/content/media/_index.md
@@ -1,7 +1,0 @@
----
-title: Media
-media: /media/rail-button.png
-name: kelelel
-alt: "0240240"
-date: 2020-04-16 16:30:00 -0500
----

--- a/data/media/2020-05-stanley-whitney.yml
+++ b/data/media/2020-05-stanley-whitney.yml
@@ -1,0 +1,5 @@
+media: /media/stanley-whitney.jpeg
+title: Stanley Whitney
+alt: A drawing of artist Stanley Whitney by Phong Bui.
+credit: Phong Bui
+date: 2020-05-05 22:46:00 -0500

--- a/data/media/the-ocean.yml
+++ b/data/media/the-ocean.yml
@@ -1,0 +1,4 @@
+media: /media/ocean.jpg
+name: The Ocean
+alt: ocean waves
+date: 2020-05-04 08:07:00 -0500

--- a/data/media/the-ocean.yml
+++ b/data/media/the-ocean.yml
@@ -1,4 +1,0 @@
-media: /media/ocean.jpg
-name: The Ocean
-alt: ocean waves
-date: 2020-05-04 08:07:00 -0500

--- a/static/media/ocean.jpg
+++ b/static/media/ocean.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd8d5845cb06e28fe29d5b0ab1c1e60555de86d62cde61bbb68506a7b08622e1
-size 1153707

--- a/static/media/rail-button.png
+++ b/static/media/rail-button.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7eea779cedde5b13c361d404098578ae23c7127e347c4ffb490e821f15d9cf2
-size 24768

--- a/static/media/rail-zoom-1.png
+++ b/static/media/rail-zoom-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69007634335875f611d4812fd6ab8f278b550f1cd23cc632a8510415b29d3696
-size 662917

--- a/static/media/stanley-whitney.jpeg
+++ b/static/media/stanley-whitney.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46c99b980ac6fd926ef01931ef6a24c0d08d38358aac80e22fee1adb3d5d678d
+size 145703

--- a/themes/brooklynrail/layouts/events-beta/card-event-past.html
+++ b/themes/brooklynrail/layouts/events-beta/card-event-past.html
@@ -39,12 +39,15 @@ The following variables transform dates and times for the event `start_date` and
   </header>
 
   {{/* Featured Image */}}
-  {{- $featured_images := .Params.featured_images -}}
   <div class="card_cover">
-    {{- range $index, $featured_image := first 1 $featured_images -}}
-    <div class="card_cover_img">
-      <img src="{{- $featured_image.img_url -}}" alt="{{- .Title -}}">
-    </div>
+    {{- $featured_images := .Params.featured_images -}}
+    {{- if $featured_images -}}
+      {{- range $img_name := first 1 $featured_images -}}
+      <div class="card_cover_img">
+        {{- $thisimg := index $.Site.Data.media ($img_name | lower) -}}
+        <img src="{{- $thisimg.media -}}" alt="">
+      </div>
+      {{- end -}}
     {{- end -}}
   </div>
   </a>

--- a/themes/brooklynrail/layouts/events-beta/card-event-past.html
+++ b/themes/brooklynrail/layouts/events-beta/card-event-past.html
@@ -42,10 +42,12 @@ The following variables transform dates and times for the event `start_date` and
   <div class="card_cover">
     {{- $featured_images := .Params.featured_images -}}
     {{- if $featured_images -}}
-      {{- range $img_name := first 1 $featured_images -}}
+      {{- range $media := first 1 $featured_images -}}
       <div class="card_cover_img">
-        {{- $thisimg := index $.Site.Data.media ($img_name | lower) -}}
-        <img src="{{- $thisimg.media -}}" alt="">
+        {{- if $media -}}
+          {{- $thisimg :=  index $.Site.Data.media ($media.media | lower) -}}
+          <img src="{{- $thisimg.media -}}" alt="">
+        {{- end -}}
       </div>
       {{- end -}}
     {{- end -}}

--- a/themes/brooklynrail/static/workflow/config.yml
+++ b/themes/brooklynrail/static/workflow/config.yml
@@ -261,8 +261,9 @@ collections:
     label: "Media" # Used in the UI
     label_singular: "Media"
     description: "TKTK"
-    folder: "content/media" # path to the folder where files are stored
-    path: "{{year}}/{{month}}/{{slug}}"
+    folder: "data/media" # path to the folder where files are stored
+    # path: "{{year}}/{{month}}/{{slug}}"
+    extension: "yml"
     create: true # Allow users to create new documents in this collection
     identifier_field: name # sets the field that is used to create the slug
     slug: "{{slug}}"

--- a/themes/brooklynrail/static/workflow/config.yml
+++ b/themes/brooklynrail/static/workflow/config.yml
@@ -11,7 +11,7 @@ logo_url: https://brooklynrail.org/images/dist/brooklynrail-logo-red.png
 
 # Backend and connections
 backend:
-  name: github
+  name: git-gateway
   repo: brooklynrail/brooklynrail-platform
   site_domain: brooklynrail.netlify.com
   base_url: https://api.netlify.com

--- a/themes/brooklynrail/static/workflow/config.yml
+++ b/themes/brooklynrail/static/workflow/config.yml
@@ -159,13 +159,22 @@ collections:
         default: ["zoom"]
         required: false
 
+
       - label: "Featured Images"
         name: "featured_images"
         widget: "list"
         hint: "Upload images through the OLD RAIL admin"
         required: false
         fields:
-          - { label: "Image URL", name: "img_url", widget: "string" }
+          - label: "Media"
+            name: "media"
+            widget: "relation"
+            collection: "media"
+            searchFields: ["media", "title"]
+            valueField: "{{slug}}"
+            required: false
+            displayFields: ["media"]
+
 
       - label: "Event Copy"
         name: "body"
@@ -261,12 +270,13 @@ collections:
     label: "Media" # Used in the UI
     label_singular: "Media"
     description: "TKTK"
-    folder: "data/media" # path to the folder where files are stored
-    # path: "{{year}}/{{month}}/{{slug}}"
+    folder: "data/media/" # path to the folder where files are stored
+    # path: "{{year}}/{{month}}"
     extension: "yml"
     create: true # Allow users to create new documents in this collection
-    identifier_field: name # sets the field that is used to create the slug
-    slug: "{{slug}}"
+    identifier_field: title # sets the field that is used to create the slug
+    slug: "{{year}}-{{month}}-{{slug}}"
+    summary: "{{title}} ({{year}}-{{month}})"
 
     fields: # The fields for each document, usually in frontmatter
       - label: "Media"
@@ -277,14 +287,9 @@ collections:
         media_library:
           config:
             multiple: true
-        fields:
-          - label: "Names"
-            name: "names"
-            widget: "string"
-            hint: "TKTK"
 
-      - label: "Name"
-        name: "name"
+      - label: "Image title"
+        name: "title"
         widget: "string"
         hint: "TKTK"
 


### PR DESCRIPTION
This set up images in the HUGO site in a better location, which solves some of the issues outlined in https://github.com/brooklynrail/brooklynrail-platform/issues/21

- [x] decide where to put images and image metadata in the repo
- [x] create a relational field in NetlifyCMS that pulls in existing images
- [x] in event pages, set images as `featured_media`

image metadata is now stored in `/data/media/` with a dated filename.

```
data/media/2020-05-stanley-whitney.yml
```