### PR TITLE
Show all past events

### DIFF
--- a/themes/brooklynrail/layouts/events/list.html
+++ b/themes/brooklynrail/layouts/events/list.html
@@ -78,7 +78,7 @@
   {{- $past_events := where $events ".Date.Unix" "<" now.Unix -}}
 
   {{/* Gets only the $past_events with a youtube_id */}}
-  {{/* {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}} */}}
+  {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}}
 
   {{- if $past_events -}}
   <section class="past_events">

--- a/themes/brooklynrail/layouts/events/list.html
+++ b/themes/brooklynrail/layouts/events/list.html
@@ -78,7 +78,7 @@
   {{- $past_events := where $events ".Date.Unix" "<" now.Unix -}}
 
   {{/* Gets only the $past_events with a youtube_id */}}
-  {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}}
+  {{/* {{- $past_events := where $past_events ".Params.youtube_id" "!=" nil -}} */}}
 
   {{- if $past_events -}}
   <section class="past_events">


### PR DESCRIPTION
This change makes it so that all the past event show up, regardless if there is a youtube video or not. In the past, we had hidden the ones without a video, and that was not right a great experience. It meant that there was no way to find past event pages until there was a video.