### PR TITLE
Making fixes to donors and sponsors data

### DIFF
--- a/content/organizations/dermot-comany.md
+++ b/content/organizations/dermot-comany.md
@@ -5,4 +5,6 @@ short_desc: Dermot Company is a vertically integrated owner, operator, &
   projects, from ground-up development and buy & hold strategies to turnaround
   situations & adaptive reuse.
 website: http://dermotcompany.com
+relationship:
+  - donor
 ---

--- a/content/organizations/kasmin-gallery.md
+++ b/content/organizations/kasmin-gallery.md
@@ -8,4 +8,6 @@ email: info@kasmingallery.com
 website: https://www.kasmingallery.com/
 instagram: https://www.instagram.com/kasmingallery/
 twitter: https://twitter.com/Kasmingallery
+relationship:
+  - donor
 ---

--- a/content/organizations/sikkema-jenkins-co.md
+++ b/content/organizations/sikkema-jenkins-co.md
@@ -4,4 +4,6 @@ email: gallery@sikkemajenkinsco.com
 website: https://www.sikkemajenkinsco.com/
 instagram: sikkemajenkins
 twitter: SikkemaJenkins
+relationship:
+  - donor
 ---

--- a/content/organizations/sperone-westwater-gallery.md
+++ b/content/organizations/sperone-westwater-gallery.md
@@ -4,4 +4,6 @@ email: info@speronewestwater.com
 website: https://www.speronewestwater.com/
 instagram: speronewestwater
 twitter: SWGallery257
+relationship:
+  - donor
 ---

--- a/content/organizations/studio-in-a-school.md
+++ b/content/organizations/studio-in-a-school.md
@@ -6,4 +6,6 @@ email: info@studioinaschool.org
 website: https://studioinaschool.org
 instagram: "studioinaschool"
 twitter: "studioinaschool"
+relationship:
+  - donor
 ---

--- a/content/organizations/the-hill-art-foundation.md
+++ b/content/organizations/the-hill-art-foundation.md
@@ -6,4 +6,6 @@ short_desc: The Hill Art Foundation is a nonprofit organization with the goal of
   education programs.
 email: ""
 website: https://hillartfoundation.org
+relationship:
+  - donor
 ---

--- a/content/organizations/the-richard-pousette-dart-foundation.md
+++ b/content/organizations/the-richard-pousette-dart-foundation.md
@@ -6,4 +6,6 @@ short_desc: Dedicated to advancing the understanding of Richard Pousette-Dart as
   exchange within the arts.
 email: info@pousette-dartfoundation.org
 website: https://pousette-dartfoundation.org
+relationship:
+  - donor
 ---

--- a/themes/brooklynrail/assets/scss/_events.scss
+++ b/themes/brooklynrail/assets/scss/_events.scss
@@ -13,6 +13,7 @@
       }
     }
     .sponsors{
+      @include u-margin-y(4);
       @include u-padding-y(2);
       @include u-padding-x(1);
       @include u-radius('lg');
@@ -29,6 +30,15 @@
       p{
         @include u-margin-y(0);
         @include u-line-height('sans', 5);
+        a{
+          @include u-text('normal');
+          @include u-text('no-underline');
+          @include u-text('indigo-warm-60v');
+          white-space: nowrap;
+          span{
+            @include u-border-bottom('1px', 'dotted', 'indigo-warm-60v');
+          }
+        }
       }
     }
   }

--- a/themes/brooklynrail/layouts/events/list.html
+++ b/themes/brooklynrail/layouts/events/list.html
@@ -50,22 +50,26 @@
       <div class="grid-row">
         <div class="grid-col-12 tablet:grid-col-10 tablet:grid-offset-1">
           <div class="sponsors">
-            <p>{{- ":heart: Our events are sponsored by: " | emojify -}}
-            {{- $sponsors := ($sponsors | uniq) -}}
-            {{- $len := (len $sponsors) -}}
-            {{- range $key, $val := ($sponsors | uniq) -}}
+            {{- $sponsor_copy := $.Site.Data.sponsor_copy.sponsored -}}
+            {{- $copy := (index ($sponsor_copy | shuffle | first 1) 0) -}}
+            <p>
+              {{- ":heart: Our events are " | emojify }}
+              {{ $copy.phrase }}:
+              {{ $sponsors := ($sponsors | uniq) -}}
+              {{- $len := (len $sponsors) -}}
+              {{- range $key, $val := ($sponsors | uniq) -}}
 
-              {{- if eq $val.Params.donor true -}}
-                {{- with $val.Params.name -}}
-                  {{- if ne $key 0 -}}, {{ end -}}
-                  {{- if eq (add $key 1) $len }}
-                    and
-                  {{ end -}}
-                  <strong>{{- $val.Params.name -}}</strong>
+                {{- if in $val.Params.relationship "donor" -}}
+                  {{- with $val.Params.name -}}
+                    {{- if ne $key 0 -}}, {{ end -}}
+                    {{- if eq (add $key 1) $len }}
+                      and
+                    {{ end -}}
+                    <a href="{{- $val.Params.website -}}?br" title="{{- $val.Params.name -}}"><span>{{- $val.Params.name -}}</span></a>
+                  {{- end -}}
                 {{- end -}}
-              {{- end -}}
 
-            {{- end -}}
+              {{- end -}}
             </p>
           </div>
         </div>

--- a/themes/brooklynrail/layouts/events/list.html
+++ b/themes/brooklynrail/layouts/events/list.html
@@ -45,6 +45,7 @@
 
       {{- end -}}
 
+
       {{/* List out the sponsors */}}
       <div class="grid-row">
         <div class="grid-col-12 tablet:grid-col-10 tablet:grid-offset-1">
@@ -53,13 +54,17 @@
             {{- $sponsors := ($sponsors | uniq) -}}
             {{- $len := (len $sponsors) -}}
             {{- range $key, $val := ($sponsors | uniq) -}}
-              {{- with $val.Params.name -}}
-              {{- if ne $key 0 -}}, {{ end -}}
-              {{- if eq (add $key 1) $len }}
-                and
-              {{ end -}}
-              <strong>{{- $val.Params.name -}}</strong>
+
+              {{- if eq $val.Params.donor true -}}
+                {{- with $val.Params.name -}}
+                  {{- if ne $key 0 -}}, {{ end -}}
+                  {{- if eq (add $key 1) $len }}
+                    and
+                  {{ end -}}
+                  <strong>{{- $val.Params.name -}}</strong>
+                {{- end -}}
               {{- end -}}
+
             {{- end -}}
             </p>
           </div>

--- a/themes/brooklynrail/layouts/events/single.html
+++ b/themes/brooklynrail/layouts/events/single.html
@@ -147,18 +147,46 @@ The class `h-event` is a root class name, `p-name`, `dt-start`, `dt-end`, `p-loc
             {{- $event_organizer = ($.Site.GetPage (printf "/%s/%s" "organizations" (index (.Params.event_organizer) 0))) -}}
             {{- end -}}
 
+
+            {{/* Get event sponsors */}}
+            {{- $event_sponsors := slice -}}
+            {{/* If there are sponsors */}}
+            {{- if .Params.event_sponsor -}}
+              {{/* Loop through and get each sponsor */}}
+              {{- range $i, $sponsor := .Params.event_sponsor -}}
+                {{- $this := ($.Site.GetPage (printf "/%s/%s" "organizations" ($sponsor))) -}}
+                {{- $event_sponsors = $event_sponsors | append $this -}}
+              {{- end -}}
+            {{- end -}}
+
+
+
             {{- $event_collection := index (.Params.collections) 0 -}}
             {{- $event_collection = $.Site.GetPage (printf "/%s/%s" "collections" $event_collection) -}}
 
             {{- if and $event_organizer $event_producer }}
             <div class="sponsor">
               <p>This talk is
-              {{- if .Params.event_sponsor -}}
+              {{- if $event_sponsors -}}
                 {{- $sponsor_copy := $.Site.Data.sponsor_copy.sponsored -}}
                 {{- $copy := (index ($sponsor_copy | shuffle | first 1) 0) -}}
-                {{- $event_sponsor := ($.Site.GetPage (printf "/%s/%s" "organizations" (index (.Params.event_sponsor) 0))) -}}
-                {{- with $event_sponsor }}
-                  {{ $copy.phrase }} our friends at <a class="u-dotted" href="{{ .Params.website }}" title="{{ .Params.name }}"><strong><span>{{ .Params.name }}</span></strong></a> and
+
+                {{- with $event_sponsors }}
+                  {{ $copy.phrase }} our friends at
+
+                  {{- $len := sub (len $event_sponsors) 1 -}}
+                  {{ range $i, $e := $event_sponsors }}
+                    <a class="u-dotted" href="{{- $e.Params.website -}}" title="{{- $e.Params.name -}}"><strong><span>{{- $e.Params.name -}}</span></strong></a>
+
+                    {{- if ge $len 2 -}}
+                      {{- if ne $i $len -}}
+                        {{- if ne $i (sub $len 1) -}}, {{ else -}}, and {{ end -}}
+                      {{- end -}}
+                    {{- else -}}
+                      {{- if ne $i (sub $len 1) -}}{{ else }} and {{ end -}}
+                    {{- end -}}
+                  {{- end }}
+                  and
                 {{ end -}}
               {{- end -}}
 

--- a/themes/brooklynrail/static/workflow/config.yml
+++ b/themes/brooklynrail/static/workflow/config.yml
@@ -478,6 +478,14 @@ collections:
         hint: "Add a short description of the person without using their name. [Max 800 characters (~120 words)]"
         required: false
 
+      - label: "Relationship"
+        name: "relationship"
+        widget: "select"
+        multiple: true
+        options: ["donor", "board-member", "advisory-board", "staff", "alumni"]
+        hint: "Donor, Board Member, Advisory Board, Staff, Alumni"
+        required: false
+
       - label: "Portrait Images"
         name: "portraits"
         widget: "list"
@@ -580,6 +588,14 @@ collections:
         name: "twitter"
         widget: "string"
         hint: "Enter the username without the @ handle [e.g. brooklynrail]"
+        required: false
+
+      - label: "Relationship"
+        name: "relationship"
+        widget: "select"
+        multiple: true
+        options: ["donor", "board-member", "advisory-board", "staff", "alumni"]
+        hint: "Donor, Board Member, Advisory Board, Staff, Alumni"
         required: false
 
   # ====================================


### PR DESCRIPTION
This change adds in relationship types to organizations and people.
- donor
- staff
- board-member
- advisory-board
- alumni

## Sponsor box
With this, it changes the way the Sponsor box appears on the events page. 
Now only the organizations that have the relationship type of "donor" will appear in that box. I also linked the orgs to their website.

![image](https://user-images.githubusercontent.com/395641/97812223-1b356900-1c3d-11eb-9575-2dd54a2a6fe6.png)


## Sponsors on event pages
Now, if there are multiple sponsors, they can appear on a single event page (donor or not). So, Spoonbill could appear next to Hill Art Foundation on an event page.

It is also possible to select the relationship from the backend of the organization or people page.

![image](https://user-images.githubusercontent.com/395641/97812229-26889480-1c3d-11eb-9377-e145eb158bba.png)


### Preview:
https://deploy-preview-1695--brooklynrail.netlify.app/events/
